### PR TITLE
Write contract addresses to `uma-contract-address.json` upon `truffle migrate`

### DIFF
--- a/packages/common/src/MigrationUtils.js
+++ b/packages/common/src/MigrationUtils.js
@@ -2,6 +2,8 @@ const fs = require("fs");
 const path = require("path");
 const tdr = require("truffle-deploy-registry");
 
+let addresses = {};
+
 // To prevent a call to migrate --reset from overwriting prevously deployed contract instances, use the following
 // command line parameters:
 // --keep_finder prevents the Finder contract from being redeployed if previously deployed.
@@ -110,6 +112,9 @@ async function deploy(deployer, network, contractType, ...args) {
     await addToTvr(contractType.address, args, network, contractInstance.constructor.network_id);
   }
 
+  // Add contract address to cache (in which later is printed out in a json file)
+  addresses[contractType.contractName] = contractInstance.address;
+
   // Return relevant info about the contract.
   return {
     contract: contractInstance,
@@ -202,5 +207,6 @@ module.exports = {
   setToExistingAddress,
   getKeysForNetwork,
   addToTdr,
-  isPublicNetwork
+  isPublicNetwork,
+  addresses
 };

--- a/packages/core/migrations/17_deploy_perpetual_creator.js
+++ b/packages/core/migrations/17_deploy_perpetual_creator.js
@@ -5,6 +5,8 @@ const TokenFactory = artifacts.require("TokenFactory");
 const Timer = artifacts.require("Timer");
 const Registry = artifacts.require("Registry");
 const { RegistryRolesEnum, getKeysForNetwork, deploy, enableControllableTiming } = require("@uma/common");
+const fs = require("fs");
+const { addresses } = require("../../common/src/MigrationUtils");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
@@ -49,4 +51,6 @@ module.exports = async function(deployer, network, accounts) {
   );
 
   await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, perpetualCreator.address);
+
+  fs.writeFileSync("../minter/test/uma-contract-address.json", JSON.stringify(addresses, null, 2));
 };


### PR DESCRIPTION
This PR exposes the UMA contract addresses to the minter unit tests, by writing a `uma-contract-address.json` onto the `../minter/test` directory upon successfully running `yarn truffle migrate`. This assumes that the `minter` repo lives at the same directory of this project (e.g. `/Developer/minter` and `/Developer/protocol`) otherwise the script that writes the json file will fail.

It is also important to note that running `truffle migrate` again, will overwrite the json file with a blank set of addresses so make sure that you only run the command once, or restart ganache if you really want to run the migration again.